### PR TITLE
Added Allow Credentials property to CORS mapping

### DIFF
--- a/src/main/java/org/prebid/cache/PBCacheApplication.java
+++ b/src/main/java/org/prebid/cache/PBCacheApplication.java
@@ -34,7 +34,8 @@ public class PBCacheApplication implements WebFluxConfigurer
         if (corsConfig.isEnabled()) {
             registry.addMapping(corsConfig.getMapping())
                     .allowedOrigins(corsConfig.getAllowedOrigins())
-                    .allowedMethods(corsConfig.getAllowedMethods());
+                    .allowedMethods(corsConfig.getAllowedMethods())
+                    .allowCredentials(corsConfig.isAllowCredentials());
         }
     }
 }

--- a/src/main/java/org/prebid/cache/config/CorsConfig.java
+++ b/src/main/java/org/prebid/cache/config/CorsConfig.java
@@ -16,4 +16,5 @@ public class CorsConfig {
     private String mapping;
     private String[] allowedOrigins;
     private String[] allowedMethods;
+    private boolean allowCredentials;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ cors:
   mapping: "/cache/**"
   allowedOrigins: "*"
   allowedMethods: "GET"
+  allowCredentials: true
 
 # cache
 cache:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,7 @@ cors:
   mapping: "/cache/**"
   allowedOrigins: "*"
   allowedMethods: "GET"
+  allowCredentials: true
 
 # cache
 cache:


### PR DESCRIPTION
Added allowCredentials property for CorsRegistry configuration. It corresponds to *Access-Control-Allow-Credentials* response header. Also, if equals to true *Access-Control-Allow-Origin* response header will be set to *Origin* request header.