### PR TITLE
Prepare for migration to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.2.RELEASE</version>
+        <version>2.1.1.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -38,26 +38,26 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <spring-boot-maven-plugin.version>2.0.2.RELEASE</spring-boot-maven-plugin.version>
+        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <spring-boot-maven-plugin.version>2.1.1.RELEASE</spring-boot-maven-plugin.version>
         <reactor-core.version>3.1.7.RELEASE</reactor-core.version>
         <lettuce-core.version>5.0.4.RELEASE</lettuce-core.version>
-        <gson.version>2.8.2</gson.version>
+        <gson.version>2.8.5</gson.version>
         <guava.version>23.0</guava.version>
         <disruptor.version>3.4.2</disruptor.version>
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.18.4</lombok.version>
         <metrics-graphite.version>4.0.2</metrics-graphite.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <rest-maven-plugin.version>0.1.4</rest-maven-plugin.version>
         <reflections.version>0.9.11</reflections.version>
-        <equals-verifier.version>2.4.3</equals-verifier.version>
+        <equals-verifier.version>3.1.3</equals-verifier.version>
         <aerospike-client.version>4.1.6</aerospike-client.version>
         <reactor-extra.version>3.1.6.RELEASE</reactor-extra.version>
         <wiremock.version>2.11.0</wiremock.version>
         <checkstyle-plugin.version>2.17</checkstyle-plugin.version>
         <checkstyle.version>7.6</checkstyle.version>
-        <jacoco-plugin.version>0.8.0</jacoco-plugin.version>
+        <jacoco-plugin.version>0.8.2</jacoco-plugin.version>
         <awaitility.version>3.0.0</awaitility.version>
     </properties>
 
@@ -336,6 +336,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <java.version>11</java.version>
+            </properties>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>

--- a/src/lombok.config
+++ b/src/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.anyConstructor.suppressConstructorProperties = false


### PR DESCRIPTION
- Upgrade dependencies
  - Spring Boot 2.1.1
  - gson 2.8.5
  - lombok 1.18.4
  - equalsverifier 3.1.3
  - JaCoCo 0.8.2
  - maven-surefire-plugin 2.22.1
  - maven-compiler-plugin 3.8.0
- Support building with both Java 8 and 11 at the same time