### PR TITLE
Clean up error logs

### DIFF
--- a/src/main/java/org/prebid/cache/handlers/CacheHandler.java
+++ b/src/main/java/org/prebid/cache/handlers/CacheHandler.java
@@ -69,6 +69,8 @@ abstract class CacheHandler extends MetricsHandler {
                                                     final ServerRequest request) {
         if (error instanceof ResourceNotFoundException) {
             log.debug(error.getMessage());
+        } else if (error instanceof BadRequestException) {
+            log.error(error.getMessage());
         } else if (error instanceof TimeoutException) {
             metricsRecorder.markMeterForTag(this.metricTagPrefix, MetricsRecorder.MeasurementTag.ERROR_TIMEDOUT);
         } else {

--- a/src/main/java/org/prebid/cache/handlers/ErrorHandler.java
+++ b/src/main/java/org/prebid/cache/handlers/ErrorHandler.java
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class ErrorHandler extends MetricsHandler {
     private static final String RESOURCE_NOT_FOUND_BAD_URL = "Resource Not Found - Bad URL.";
-    private static final String RESOURCE_NOT_FOUND = "Resource Not Found.";
+    private static final String RESOURCE_NOT_FOUND = "Resource Not Found: uuid %s";
     private static final String INVALID_PARAMETERS = "Invalid Parameter(s): uuid not found.";
     private static final String NO_ELEMENTS_FOUND = "No Elements Found.";
 
@@ -25,8 +25,8 @@ public class ErrorHandler extends MetricsHandler {
         this.builder = builder;
     }
 
-    static Mono<ServerResponse> createResourceNotFound() {
-        return Mono.error(new ResourceNotFoundException(RESOURCE_NOT_FOUND));
+    static Mono<ServerResponse> createResourceNotFound(String uuid) {
+        return Mono.error(new ResourceNotFoundException(String.format(RESOURCE_NOT_FOUND, uuid)));
     }
 
     static Mono<ServerResponse> createInvalidParameters() {

--- a/src/main/java/org/prebid/cache/handlers/GetCacheHandler.java
+++ b/src/main/java/org/prebid/cache/handlers/GetCacheHandler.java
@@ -70,7 +70,7 @@ public class GetCacheHandler extends CacheHandler {
                             return Mono.error(new UnsupportedMediaTypeException(UNSUPPORTED_MEDIATYPE));
                         }
                     })
-                    .switchIfEmpty(ErrorHandler.createResourceNotFound());
+                    .switchIfEmpty(ErrorHandler.createResourceNotFound(normalizedId));
             return finalizeResult(responseMono, request, timerContext);
         }).orElseGet(() -> {
             val responseMono = ErrorHandler.createInvalidParameters();


### PR DESCRIPTION
Minor fix to get cleaner logs when UUID wasn't found by not logging the whole stack trace (which is useless anyways).