### PR TITLE
Maven release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </organization>
 
     <scm>
-        <developerConnection>scm:git:git@github.rp-core.com:ContainerTag/prebid-cache-java.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rubicon-project/prebid-cache-java.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -41,7 +41,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven-source-plugin.version>maven-release-plugin3.0.1</maven-source-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -351,7 +351,7 @@
                 <version>${maven-release-plugin.version}</version>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>
-                    <scmCommentPrefix xml:space="precache">Prebid Cache </scmCommentPrefix>
+                    <scmCommentPrefix xml:space="preserve">Prebid Cache </scmCommentPrefix>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
         <url>http://prebid.org/</url>
     </organization>
 
+    <scm>
+        <developerConnection>scm:git:git@github.com:rubicon-project/prebid-cache-java.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -36,7 +41,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-source-plugin.version>maven-release-plugin3.0.1</maven-source-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -59,6 +64,7 @@
         <jacoco-plugin.version>0.8.2</jacoco-plugin.version>
         <awaitility.version>3.0.0</awaitility.version>
         <resilience4j.version>0.13.2</resilience4j.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     </properties>
 
     <dependencies>
@@ -338,6 +344,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <scmCommentPrefix xml:space="precache">Prebid Cache </scmCommentPrefix>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </organization>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:rubicon-project/prebid-cache-java.git</developerConnection>
+        <developerConnection>scm:git:git@github.rp-core.com:ContainerTag/prebid-cache-java.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
This PR adds `maven-release-plugin`.
It means from this time `Prebid Cache` will follow [Semantic Versioning Specification (SemVer)](https://semver.org/) for releases.

Example usage to add new release tag:
```
mvn release:clean \
        release:prepare -DreleaseVersion=1.11.0 -DdevelopmentVersion=1.12.0-SNAPSHOT
```
This will state `1.11.0` as released version and set `1.12.0-SNAPSHOT` as version under development.