### PR TITLE
Upgrade lettuce and turn on cluster topology refresh to support failover scenario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <spring-boot-maven-plugin.version>2.1.2.RELEASE</spring-boot-maven-plugin.version>
-        <lettuce-core.version>5.1.8.RELEASE</lettuce-core.version>
+        <lettuce-core.version>6.0.1.RELEASE</lettuce-core.version>
         <gson.version>2.8.5</gson.version>
         <guava.version>23.0</guava.version>
         <disruptor.version>3.4.2</disruptor.version>

--- a/src/main/java/org/prebid/cache/repository/redis/RedisPropertyConfiguration.java
+++ b/src/main/java/org/prebid/cache/repository/redis/RedisPropertyConfiguration.java
@@ -45,6 +45,8 @@ public class RedisPropertyConfiguration {
         @Singular
         List<String> nodes;
 
+        boolean enableTopologyRefresh;
+
         Integer topologyPeriodicRefreshPeriod;
     }
 
@@ -68,13 +70,17 @@ public class RedisPropertyConfiguration {
     }
 
     private ClusterClientOptions createRedisClusterOptions() {
+        final ClusterTopologyRefreshOptions topologyRefreshOptions = cluster.isEnableTopologyRefresh()
+                ? ClusterTopologyRefreshOptions.builder()
+                .enablePeriodicRefresh()
+                .refreshPeriod(Duration.of(cluster.getTopologyPeriodicRefreshPeriod(), ChronoUnit.SECONDS))
+                .enableAllAdaptiveRefreshTriggers()
+                .build()
+                : null;
+
         return ClusterClientOptions.builder()
                 .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
-                .topologyRefreshOptions(ClusterTopologyRefreshOptions.builder()
-                        .enablePeriodicRefresh()
-                        .refreshPeriod(Duration.of(cluster.getTopologyPeriodicRefreshPeriod(), ChronoUnit.SECONDS))
-                        .enableAllAdaptiveRefreshTriggers()
-                        .build())
+                .topologyRefreshOptions(topologyRefreshOptions)
                 .build();
     }
 

--- a/src/main/java/org/prebid/cache/repository/redis/RedisPropertyConfiguration.java
+++ b/src/main/java/org/prebid/cache/repository/redis/RedisPropertyConfiguration.java
@@ -1,9 +1,12 @@
 package org.prebid.cache.repository.redis;
 
+import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.RedisStringReactiveCommands;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import lombok.AllArgsConstructor;
@@ -16,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,6 +44,8 @@ public class RedisPropertyConfiguration {
 
         @Singular
         List<String> nodes;
+
+        Integer topologyPeriodicRefreshPeriod;
     }
 
     private RedisURI createRedisURI(String host, int port) {
@@ -47,7 +53,7 @@ public class RedisPropertyConfiguration {
         final RedisURI.Builder builder = RedisURI.Builder.redis(host, port)
                 .withTimeout(Duration.ofMillis(timeout));
         if (password != null) {
-            builder.withPassword(password);
+            builder.withPassword((CharSequence) password);
         }
 
         return builder.build();
@@ -59,6 +65,17 @@ public class RedisPropertyConfiguration {
                 .map(node -> node.split(":"))
                 .map(host -> createRedisURI(host[0], Integer.parseInt(host[1])))
                 .collect(Collectors.toList());
+    }
+
+    private ClusterClientOptions createRedisClusterOptions() {
+        return ClusterClientOptions.builder()
+                .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                .topologyRefreshOptions(ClusterTopologyRefreshOptions.builder()
+                        .enablePeriodicRefresh()
+                        .refreshPeriod(Duration.of(cluster.getTopologyPeriodicRefreshPeriod(), ChronoUnit.SECONDS))
+                        .enableAllAdaptiveRefreshTriggers()
+                        .build())
+                .build();
     }
 
     @Bean(destroyMethod = "shutdown")
@@ -76,7 +93,10 @@ public class RedisPropertyConfiguration {
     @Bean(destroyMethod = "shutdown")
     @ConditionalOnProperty(prefix = "spring.redis", name = "host", matchIfMissing = true, havingValue = "null")
     RedisClusterClient clusterClient() {
-        return RedisClusterClient.create(createRedisClusterURIs());
+        final RedisClusterClient redisClusterClient = RedisClusterClient.create(createRedisClusterURIs());
+        redisClusterClient.setOptions(createRedisClusterOptions());
+
+        return redisClusterClient;
     }
 
     @Bean(destroyMethod = "close")


### PR DESCRIPTION
This PR introduces a new configuration parameter `spring.redis.cluster.topology-periodic-refresh-period` that has to be set when Redis cluster is configured. It defines how frequently Redis client will discover cluster topology changes.

Please note that there is another strategy of topology refresh turned on called "adaptive" that will trigger refresh in particular circumstances.